### PR TITLE
Add MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 NoMoreiTunes Developers
+Copyright (c) 2010-2018 Florian Pichler & NoMoreiTunes contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Long overdue. Using Creative Commons, which my uninformed self decided to do back in 2012 isn't a practical licensing for software projects and I prefer MIT anyway. 

Thanks for @jdf221 for reminding me.